### PR TITLE
feat/change-field-name-for-allowed_only-in-function-search-api 

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ import { FunctionDefinitionFormat } from '@aci-sdk/aci';
 const functions = await client.functions.search({
   app_names: ["BRAVE_SEARCH", "TAVILY"],
   intent: "I want to search the web",
-  allowed_apps_only: false, // If true, only returns functions of apps that are allowed by the agent/accessor, identified by the api key.
+  allowed_only: false, // If true, only returns the enabled functions of apps that are allowed by the agent/accessor, identified by the api key.
   format: FunctionDefinitionFormat.OPENAI, // The format of the functions, can be OPENAI, ANTHROPIC, BASIC (name and description only)
   limit: 10,
   offset: 0
@@ -233,7 +233,7 @@ const searchResults = await client.handleFunctionCall({
     limit: 10
   },
   linkedAccountOwnerId: 'user123',
-  allowedAppsOnly: false,
+  allowedOnly: false,
   format: FunctionDefinitionFormat.OPENAI_RESPONSES
 });
 

--- a/__tests__/meta_functions/aci_handle_execution.test.ts
+++ b/__tests__/meta_functions/aci_handle_execution.test.ts
@@ -63,7 +63,7 @@ describe('AI Integration Tests', () => {
       functionName: searchToolCall.name,
       functionArguments: searchArguments,
       linkedAccountOwnerId: 'test-user-id',
-      allowedAppsOnly: false,
+      allowedOnly: false,
       format: FunctionDefinitionFormat.OPENAI_RESPONSES,
     });
 

--- a/__tests__/meta_functions/aci_search_functions_mock.test.ts
+++ b/__tests__/meta_functions/aci_search_functions_mock.test.ts
@@ -76,7 +76,7 @@ describe('ACI_SEARCH_FUNCTIONS Meta Function', () => {
         intent: 'test search',
         limit: 10,
         offset: 0,
-        allowed_apps_only: undefined,
+        allowed_only: undefined,
         format: 'openai',
       });
       expect(result).toEqual(mockResponse);
@@ -97,7 +97,7 @@ describe('ACI_SEARCH_FUNCTIONS Meta Function', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('should pass along the allowed_apps_only flag', async () => {
+    it('should pass along the allowed_only flag', async () => {
       mock.onGet('/functions/search').reply(200, mockResponse);
 
       const linkedAccountOwnerId = 'user-123';
@@ -105,11 +105,11 @@ describe('ACI_SEARCH_FUNCTIONS Meta Function', () => {
         functionName: 'ACI_SEARCH_FUNCTIONS',
         functionArguments: { intent: 'test search' },
         linkedAccountOwnerId,
-        allowedAppsOnly: true,
+        allowedOnly: true,
       });
 
       expect(mock.history.get.length).toBe(1);
-      expect(mock.history.get[0].params).toHaveProperty('allowed_apps_only', true);
+      expect(mock.history.get[0].params).toHaveProperty('allowed_only', true);
       expect(result).toEqual(mockResponse);
     });
   });

--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -111,7 +111,7 @@ async function main() {
     console.log('\nSearching functions with OPENAI_RESPONSES format...');
     const searchResults = await client.functions.search({
       intent: 'I want to search the web',
-      allowed_apps_only: false,
+      allowed_only: false,
       limit: 5,
       format: FunctionDefinitionFormat.OPENAI_RESPONSES,
     });

--- a/examples/openai-dynamic-tool.ts
+++ b/examples/openai-dynamic-tool.ts
@@ -66,7 +66,7 @@ async function main() {
     functionName: searchToolCall.name,
     functionArguments: searchArguments,
     linkedAccountOwnerId: 'your-user-id', // Replace with actual user ID
-    allowedAppsOnly: false,
+    allowedOnly: false,
     format: FunctionDefinitionFormat.OPENAI_RESPONSES,
   });
 
@@ -107,7 +107,7 @@ async function main() {
     functionName: executeToolCall.name,
     functionArguments: executeArguments,
     linkedAccountOwnerId: process.env.LINKED_ACCOUNT_OWNER_ID as string,
-    allowedAppsOnly: false,
+    allowedOnly: false,
     format: FunctionDefinitionFormat.OPENAI_RESPONSES,
   });
 

--- a/examples/openai-static-tool.ts
+++ b/examples/openai-static-tool.ts
@@ -61,7 +61,7 @@ async function main() {
       functionName: toolCall.name,
       functionArguments: JSON.parse(toolCall.arguments),
       linkedAccountOwnerId: LINKED_ACCOUNT_OWNER_ID,
-      allowedAppsOnly: true,
+      allowedOnly: true,
       format: FunctionDefinitionFormat.OPENAI_RESPONSES,
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aci-sdk/aci",
-  "version": "0.1.7-beta",
+  "version": "0.1.8-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aci-sdk/aci",
-      "version": "0.1.7-beta",
+      "version": "0.1.8-beta",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.7",

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,10 +19,15 @@ import {
 import { FunctionDefinitionFormat } from './types/functions';
 
 interface HandleFunctionCallParams {
+  /** Name of the function to be called */
   functionName: string;
+  /** Object containing the input arguments for the function */
   functionArguments: Record<string, any>;
+  /** Specifies the end-user (account owner) on behalf of whom to execute functions */
   linkedAccountOwnerId?: string;
-  allowedAppsOnly?: boolean;
+  /** If true, only returns enabled functions from apps that are allowed by the agent/accessor */
+  allowedOnly?: boolean;
+  /** Format of the function definition (for ACI_SEARCH_FUNCTIONS) */
   format?: FunctionDefinitionFormat;
 }
 
@@ -101,18 +106,23 @@ export class ACI {
    * @param functionName - Name of the function to be called
    * @param functionArguments - Object containing the input arguments for the function
    * @param linkedAccountOwnerId - Specifies the end-user (account owner) on behalf of whom to execute functions
-   * @param allowedAppsOnly - If true, only returns functions/apps that are allowed to be used by the agent/accessor
+   * @param allowedOnly - If true, only returns enabled functions from apps that are allowed to be used by the agent/accessor
    * @param format - Format of the function definition (for ACI_SEARCH_FUNCTIONS)
    * @returns The result of the function execution (varies based on the function)
    */
   public async handleFunctionCall(params: HandleFunctionCallParams): Promise<any> {
-    const { functionName, functionArguments, linkedAccountOwnerId, allowedAppsOnly, format } =
-      params;
+    const {
+      functionName,
+      functionArguments,
+      linkedAccountOwnerId,
+      allowedOnly,
+      format,
+    } = params;
 
     if (functionName === ACI_SEARCH_FUNCTIONS) {
       const functions = await this.functions.search({
         ...functionArguments,
-        allowed_apps_only: allowedAppsOnly,
+        allowed_only: allowedOnly,
         format: format,
       });
 

--- a/src/resource/functions.ts
+++ b/src/resource/functions.ts
@@ -4,6 +4,7 @@ import {
   FunctionExecutionResult,
   FunctionDefinition,
   FunctionDefinitionFormat,
+  SearchFunctionsParams,
 } from '../types/functions';
 import { ValidationError } from '../exceptions';
 import { FunctionsSchema } from '../schemas';
@@ -28,22 +29,16 @@ export class FunctionsResource extends APIResource {
    * @param params - Search parameters
    * @param params.app_names - List of app names to filter functions by
    * @param params.intent - Search results will be sorted by relevance to this intent
-   * @param params.allowed_apps_only - If true, only returns functions of apps that are allowed by the agent/accessor
+   * @param params.allowed_only - If true, only returns enabled functions from apps that are allowed by the agent/accessor
    * @param params.format - Format of the function definitions to return
    * @param params.limit - For pagination, maximum number of functions to return
    * @param params.offset - For pagination, number of functions to skip before returning results
    * @returns Promise resolving to an array of function definitions matching the search criteria
    * @throws Various exceptions for different HTTP status codes
    */
-  async search(params: {
-    app_names?: string[];
-    intent?: string;
-    allowed_apps_only?: boolean;
-    format?: FunctionDefinitionFormat;
-    limit?: number;
-    offset?: number;
-  }): Promise<FunctionDefinition[]> {
+  async search(params: SearchFunctionsParams): Promise<FunctionDefinition[]> {
     try {
+
       // Validate params with Zod
       const validatedParams = this.validateInput(FunctionsSchema.search, params);
 

--- a/src/schemas/functions.ts
+++ b/src/schemas/functions.ts
@@ -5,7 +5,7 @@ export const FunctionsSchema = {
   search: z.object({
     app_names: z.array(z.string()).optional(),
     intent: z.string().optional(),
-    allowed_apps_only: z.boolean().optional(),
+    allowed_only: z.boolean().optional(),
     format: z.nativeEnum(FunctionDefinitionFormat).optional(),
     limit: z.number().int().positive().optional(),
     offset: z.number().int().nonnegative().optional(),

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -66,8 +66,8 @@ export interface SearchFunctionsParams {
   app_names?: string[];
   /** Intent to search for relevant functions */
   intent?: string;
-  /** If true, only returns functions/apps that are allowed to be used by the agent/accessor */
-  allowed_apps_only?: boolean;
+  /** If true, only returns enabled functions from apps that are allowed by the agent/accessor */
+  allowed_only?: boolean;
   /** Format of the function definition to return */
   format?: FunctionDefinitionFormat;
   /** Maximum number of functions to return */


### PR DESCRIPTION
changed the field name from `allowed_apps_only` to `allowed_only` for function search API for the function level enablement settings

Ticket:
https://www.notion.so/Update-TS-Python-SDK-to-use-allowed_only-field-2498378d6a4780019d40e8de433a39d7?v=c135b6e7f76243819caf99a83e291380&source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Renamed API parameters: allowed_apps_only → allowed_only (functions search) and allowedAppsOnly → allowedOnly (function call). Behavior unchanged; continues to filter to enabled functions from allowed apps.
* Documentation
  * Updated README and examples to use the new parameter names with clarified descriptions.
* Tests
  * Updated test cases and assertions to reflect the renamed parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->