### PR TITLE
feat/replacing-allowed_apps_only-field-in-function-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ const searchResults = await client.handleFunctionCall({
     limit: 10
   },
   linkedAccountOwnerId: 'user123',
-  allowedAppsOnly: false,
+  allowedOnly: false,
   format: FunctionDefinitionFormat.OPENAI_RESPONSES
 });
 

--- a/__tests__/meta_functions/aci_handle_execution.test.ts
+++ b/__tests__/meta_functions/aci_handle_execution.test.ts
@@ -63,7 +63,7 @@ describe('AI Integration Tests', () => {
       functionName: searchToolCall.name,
       functionArguments: searchArguments,
       linkedAccountOwnerId: 'test-user-id',
-      allowedAppsOnly: false,
+      allowedOnly: false,
       format: FunctionDefinitionFormat.OPENAI_RESPONSES,
     });
 

--- a/__tests__/meta_functions/aci_search_functions_mock.test.ts
+++ b/__tests__/meta_functions/aci_search_functions_mock.test.ts
@@ -105,7 +105,7 @@ describe('ACI_SEARCH_FUNCTIONS Meta Function', () => {
         functionName: 'ACI_SEARCH_FUNCTIONS',
         functionArguments: { intent: 'test search' },
         linkedAccountOwnerId,
-        allowedAppsOnly: true,
+        allowedOnly: true,
       });
 
       expect(mock.history.get.length).toBe(1);

--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -18,7 +18,7 @@ async function main() {
     console.log('Searching for apps...');
     const apps = await client.apps.search({
       intent: 'I want to search the web',
-      allowed_apps_only: false,
+      allowed_only: false,
       include_functions: true,
       limit: 5,
     });
@@ -111,7 +111,7 @@ async function main() {
     console.log('\nSearching functions with OPENAI_RESPONSES format...');
     const searchResults = await client.functions.search({
       intent: 'I want to search the web',
-      allowed_apps_only: false,
+      allowed_only: false,
       limit: 5,
       format: FunctionDefinitionFormat.OPENAI_RESPONSES,
     });

--- a/examples/openai-dynamic-tool.ts
+++ b/examples/openai-dynamic-tool.ts
@@ -66,7 +66,7 @@ async function main() {
     functionName: searchToolCall.name,
     functionArguments: searchArguments,
     linkedAccountOwnerId: 'your-user-id', // Replace with actual user ID
-    allowedAppsOnly: false,
+    allowedOnly: false,
     format: FunctionDefinitionFormat.OPENAI_RESPONSES,
   });
 
@@ -107,7 +107,6 @@ async function main() {
     functionName: executeToolCall.name,
     functionArguments: executeArguments,
     linkedAccountOwnerId: process.env.LINKED_ACCOUNT_OWNER_ID as string,
-    allowedAppsOnly: false,
     format: FunctionDefinitionFormat.OPENAI_RESPONSES,
   });
 

--- a/examples/openai-static-tool.ts
+++ b/examples/openai-static-tool.ts
@@ -61,7 +61,6 @@ async function main() {
       functionName: toolCall.name,
       functionArguments: JSON.parse(toolCall.arguments),
       linkedAccountOwnerId: LINKED_ACCOUNT_OWNER_ID,
-      allowedAppsOnly: true,
       format: FunctionDefinitionFormat.OPENAI_RESPONSES,
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -115,7 +115,7 @@ export class ACI {
     if (functionName === ACI_SEARCH_FUNCTIONS) {
       const functions = await this.functions.search({
         ...functionArguments,
-        allowed_only: allowedOnly || allowedAppsOnly,
+        allowed_only: allowedOnly ?? allowedAppsOnly,
         format: format,
       });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,10 +19,17 @@ import {
 import { FunctionDefinitionFormat } from './types/functions';
 
 interface HandleFunctionCallParams {
+  /** Name of the function to be called */
   functionName: string;
+  /** Dictionary containing all input arguments required to execute the specified function */
   functionArguments: Record<string, any>;
+  /** Specifies with credentials of which linked account the function should be executed */
   linkedAccountOwnerId?: string;
+  /** @deprecated Use allowedOnly instead. If true, only returns enabled functions of apps that are allowed to be used by the agent/accessor */
   allowedAppsOnly?: boolean;
+  /** If true, only returns enabled functions of apps that are allowed to be used by the agent/accessor. If false, returns all functions of all apps. */
+  allowedOnly?: boolean;
+  /** Format of the function definition to return */
   format?: FunctionDefinitionFormat;
 }
 
@@ -97,22 +104,18 @@ export class ACI {
    *
    * It supports handling built-in meta functions (ACI_SEARCH_FUNCTIONS, ACI_EXECUTE_FUNCTION) and also handling
    * executing third-party functions directly.
-   *
-   * @param functionName - Name of the function to be called
-   * @param functionArguments - Object containing the input arguments for the function
-   * @param linkedAccountOwnerId - Specifies the end-user (account owner) on behalf of whom to execute functions
-   * @param allowedAppsOnly - If true, only returns functions/apps that are allowed to be used by the agent/accessor
-   * @param format - Format of the function definition (for ACI_SEARCH_FUNCTIONS)
+   * 
+   * @param {HandleFunctionCallParams} params
    * @returns The result of the function execution (varies based on the function)
    */
   public async handleFunctionCall(params: HandleFunctionCallParams): Promise<any> {
-    const { functionName, functionArguments, linkedAccountOwnerId, allowedAppsOnly, format } =
+    const { functionName, functionArguments, linkedAccountOwnerId, allowedOnly, allowedAppsOnly, format } =
       params;
 
     if (functionName === ACI_SEARCH_FUNCTIONS) {
       const functions = await this.functions.search({
         ...functionArguments,
-        allowed_apps_only: allowedAppsOnly,
+        allowed_only: allowedOnly || allowedAppsOnly,
         format: format,
       });
 

--- a/src/resource/functions.ts
+++ b/src/resource/functions.ts
@@ -35,10 +35,13 @@ export class FunctionsResource extends APIResource {
       // Validate params with Zod
       const validatedParams = this.validateInput(FunctionsSchema.search, params);
 
+      const { allowed_only, allowed_apps_only, format, ...rest } = validatedParams;
+
       // Create a new params object with the format converted to lowercase
       const apiParams = {
-        ...validatedParams,
-        format: this.formatToLowercase(validatedParams.format),
+        ...rest,
+        allowed_only: allowed_only ?? allowed_apps_only,
+        format: this.formatToLowercase(format),
       };
 
       const response = await this.client.get('/functions/search', {

--- a/src/resource/functions.ts
+++ b/src/resource/functions.ts
@@ -4,6 +4,7 @@ import {
   FunctionExecutionResult,
   FunctionDefinition,
   FunctionDefinitionFormat,
+  SearchFunctionsParams,
 } from '../types/functions';
 import { ValidationError } from '../exceptions';
 import { FunctionsSchema } from '../schemas';
@@ -25,24 +26,11 @@ export class FunctionsResource extends APIResource {
    * Searches for functions based on specified criteria.
    * TODO: return specific type for returned functions based on FunctionDefinitionFormat
    *
-   * @param params - Search parameters
-   * @param params.app_names - List of app names to filter functions by
-   * @param params.intent - Search results will be sorted by relevance to this intent
-   * @param params.allowed_apps_only - If true, only returns functions of apps that are allowed by the agent/accessor
-   * @param params.format - Format of the function definitions to return
-   * @param params.limit - For pagination, maximum number of functions to return
-   * @param params.offset - For pagination, number of functions to skip before returning results
+   * @param {SearchFunctionsParams} params
    * @returns Promise resolving to an array of function definitions matching the search criteria
    * @throws Various exceptions for different HTTP status codes
    */
-  async search(params: {
-    app_names?: string[];
-    intent?: string;
-    allowed_apps_only?: boolean;
-    format?: FunctionDefinitionFormat;
-    limit?: number;
-    offset?: number;
-  }): Promise<FunctionDefinition[]> {
+  async search(params: SearchFunctionsParams): Promise<FunctionDefinition[]> {
     try {
       // Validate params with Zod
       const validatedParams = this.validateInput(FunctionsSchema.search, params);

--- a/src/schemas/functions.ts
+++ b/src/schemas/functions.ts
@@ -6,6 +6,7 @@ export const FunctionsSchema = {
     app_names: z.array(z.string()).optional(),
     intent: z.string().optional(),
     allowed_apps_only: z.boolean().optional(),
+    allowed_only: z.boolean().optional(),
     format: z.nativeEnum(FunctionDefinitionFormat).optional(),
     limit: z.number().int().positive().optional(),
     offset: z.number().int().nonnegative().optional(),

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -66,8 +66,10 @@ export interface SearchFunctionsParams {
   app_names?: string[];
   /** Intent to search for relevant functions */
   intent?: string;
-  /** If true, only returns functions/apps that are allowed to be used by the agent/accessor */
+  /** @deprecated Use allowed_only instead. If true, only returns enabled functions of apps that are allowed to be used by the agent/accessor */
   allowed_apps_only?: boolean;
+  /** If true, only returns enabled functions of apps that are allowed to be used by the agent/accessor. If false, returns all functions of all apps. */
+  allowed_only?: boolean;
   /** Format of the function definition to return */
   format?: FunctionDefinitionFormat;
   /** Maximum number of functions to return */


### PR DESCRIPTION
replace `allowed_apps_only` with `allowed_only` in function search method
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the allowed_apps_only field with allowed_only in the function search method and related code to improve clarity and consistency.

- **Refactors**
 - Updated all references, types, and documentation to use allowed_only instead of allowed_apps_only.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added allowed_only option for search and function-call filters; allowed_apps_only is deprecated but still supported.
* Documentation
  * Examples and docs updated to use allowed_only and clarify parameter behavior.
* Tests
  * Tests updated to cover allowed_only and ensure correct mapping to legacy behavior.
* Refactor
  * Normalized search parameter shapes and validation; function-call input now accepts a single params object for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->